### PR TITLE
Fix: Prevent client-side error in EditBOMItemForm

### DIFF
--- a/app/components/EditBOMItemForm.tsx
+++ b/app/components/EditBOMItemForm.tsx
@@ -35,7 +35,7 @@ const EditBOMItemForm: React.FC<EditBOMItemFormProps> = ({ initialData, onBOMIte
     setUnit(initialData.unit);
     setSupplier(initialData.supplier || '');
     setCustomFields(
-      initialData.customFields.map(cf => ({
+      (initialData.customFields || []).map(cf => ({
         ...cf,
         localId: `existing-${cf.id}`,
         status: 'existing',


### PR DESCRIPTION
The form would throw a TypeError if a BOM item's `customFields` was undefined when initializing the component's state. This typically occurred when editing a BOM item that had no custom fields.

The fix ensures that `initialData.customFields` is defaulted to an empty array before attempting to call `.map()` on it within the `useEffect` hook. This prevents the runtime error and allows the form to load correctly for BOM items with or without custom fields.